### PR TITLE
Use Module.prepend when possible

### DIFF
--- a/lib/jquery-rjs.rb
+++ b/lib/jquery-rjs.rb
@@ -6,6 +6,11 @@ unless defined? JQUERY_VAR
 end
 
 module JqueryRjs
+  def use_alias_method_chain?
+    @use_alias_method_chain ||= RUBY_VERSION < '2'
+  end
+  module_function :use_alias_method_chain?
+
   class Engine < Rails::Engine
     initializer 'jquery-rjs.initialize' do
       ActiveSupport.on_load(:action_controller) do

--- a/lib/jquery-rjs/rendering.rb
+++ b/lib/jquery-rjs/rendering.rb
@@ -1,13 +1,23 @@
 require 'action_view/helpers/rendering_helper'
 
-ActionView::Helpers::RenderingHelper.module_eval do
-  def render_with_update(options = {}, locals = {}, &block)
+module JqueryRjs::RenderingHelper
+  method_name = "render#{'_with_update' if RUBY_VERSION < '2'}"
+  define_method(method_name) do |options = {}, locals = {}, &block|
     if options == :update
       update_page(&block)
     else
-      render_without_update(options, locals, &block)
+      args = options, locals, block
+      RUBY_VERSION < '2' ? render_without_update(*args) : super(*args)
     end
   end
-  
-  alias_method_chain :render, :update
+end
+
+
+if RUBY_VERSION < '2'
+  ActionView::Helpers::RenderingHelper.module_eval do
+    include JqueryRjs::RenderingHelper
+    alias_method_chain :render, :update
+  end
+else
+  ActionView::Helpers::RenderingHelper.prepend(JqueryRjs::RenderingHelper)
 end

--- a/lib/jquery-rjs/rendering.rb
+++ b/lib/jquery-rjs/rendering.rb
@@ -1,19 +1,19 @@
 require 'action_view/helpers/rendering_helper'
 
 module JqueryRjs::RenderingHelper
-  method_name = "render#{'_with_update' if RUBY_VERSION < '2'}"
+  method_name = "render#{'_with_update' if JqueryRjs.use_alias_method_chain?}"
   define_method(method_name) do |options = {}, locals = {}, &block|
     if options == :update
       update_page(&block)
     else
       args = options, locals, block
-      RUBY_VERSION < '2' ? render_without_update(*args) : super(*args)
+      JqueryRjs.use_alias_method_chain? ? render_without_update(*args) : super(*args)
     end
   end
 end
 
 
-if RUBY_VERSION < '2'
+if JqueryRjs.use_alias_method_chain?
   ActionView::Helpers::RenderingHelper.module_eval do
     include JqueryRjs::RenderingHelper
     alias_method_chain :render, :update

--- a/lib/jquery-rjs/selector_assertions.rb
+++ b/lib/jquery-rjs/selector_assertions.rb
@@ -197,7 +197,7 @@ module JqueryRjs::SelectorAssertions
 
   # +assert_select+ and +css_select+ call this to obtain the content in the HTML
   # page, or from all the RJS statements, depending on the type of response.
-  define_method("response_from_page#{'_with_rjs' if RUBY_VERSION < '2'}") do
+  define_method("response_from_page#{'_with_rjs' if JqueryRjs.use_alias_method_chain?}") do
     content_type = @response.content_type
 
     if content_type && Mime[:js] =~ content_type
@@ -216,7 +216,7 @@ module JqueryRjs::SelectorAssertions
 
       root
     else
-      RUBY_VERSION < '2' ? response_from_page_without_rjs : super()
+      JqueryRjs.use_alias_method_chain? ? response_from_page_without_rjs : super()
     end
   end
 
@@ -240,7 +240,7 @@ module_to_patch = if defined?(ActionDispatch::Assertions::SelectorAssertions)
                     Rails::Dom::Testing::Assertions::SelectorAssertions
                   end
 
-if RUBY_VERSION < '2'
+if JqueryRjs.use_alias_method_chain?
   module_to_patch.module_eval do
     include JqueryRjs::SelectorAssertions
     alias_method_chain :response_from_page, :rjs


### PR DESCRIPTION
**WARNING: See [this comment](https://github.com/ManageIQ/jquery-rjs/pull/1#issuecomment-250796194). Basically, this removes the deprecation on Rails 5 but the functionality is probably broken (for previous versions as well), anyway. On ManageIQ we just don't use it, so it doesn't matter really. The bottom line is that this gem is essentially a wasteland and nobody should honestly use it. The better solution is just to stop using RJS.**

This removes current deprecation warnings with Rails 5 and will allow continued use of the gem once alias_method_chain is removed from ActiveSupport.

This change allows both patches in this gem to utilize Ruby 2's `Module.prepend` instead of ActiveSupport's `alias_method_chain` when possible. Normally I would drop support of Ruby < 2 and just rely on prepend, but as this gem is largely for legacy purposes this now allows for both methods depending on the version of Ruby used.
## Testing / QA

Annoyingly, I have no idea how to test this. The gem's test suite is in such a disarray that I don't think they'll ever really pass at this point (before these changes), and using the RJS functionality we utilize on ManageIQ doesn't actually trigger the code patched here. So... yeah. Careful code review I guess.
