### PR TITLE
Updates for Rails 6.0

### DIFF
--- a/lib/action_view/template/handlers/rjs.rb
+++ b/lib/action_view/template/handlers/rjs.rb
@@ -5,8 +5,9 @@ module ActionView
       class_attribute :default_format
       self.default_format = Mime[:js]
 
-      def call(template)
-        "update_page do |page|;#{template.source}\nend"
+      def call(template, source=nil)
+        source ||= template.source
+        "update_page do |page|;#{source}\nend"
       end
     end
   end

--- a/lib/jquery-rjs/rendering.rb
+++ b/lib/jquery-rjs/rendering.rb
@@ -8,6 +8,7 @@ ActionView::Helpers::RenderingHelper.module_eval do
       render_without_update(options, locals, &block)
     end
   end
-  
-  alias_method_chain :render, :update
+
+  alias_method :render_without_update, :render
+  alias_method :render, :render_with_update
 end

--- a/lib/jquery-rjs/selector_assertions.rb
+++ b/lib/jquery-rjs/selector_assertions.rb
@@ -219,7 +219,8 @@ end
       response_from_page_without_rjs
     end
   end
-  alias_method_chain :response_from_page, :rjs
+  alias_method :response_from_page_without_rjs, :response_from_page
+  alias_method :response_from_page, :response_from_page_with_rjs
 
   # Unescapes a RJS string.
   def unescape_rjs(rjs_string)


### PR DESCRIPTION
- Removes usages of `alias_method_chain`
- Updates calls to `ActionView::Template::Handlers::RJS.call`

Probably should be a major version update for this gem, but that can be up for discussion.