### PR TITLE
Updates for Rails 6.0

### DIFF
--- a/lib/action_view/template/handlers/rjs.rb
+++ b/lib/action_view/template/handlers/rjs.rb
@@ -5,8 +5,9 @@ module ActionView
       class_attribute :default_format
       self.default_format = Mime[:js]
 
-      def call(template)
-        "update_page do |page|;#{template.source}\nend"
+      def call(template, source=nil)
+        source ||= template.source
+        "update_page do |page|;#{source}\nend"
       end
     end
   end


### PR DESCRIPTION
Redo of https://github.com/ManageIQ/jquery-rjs/pull/2

- Updates calls to ActionView::Template::Handlers::RJS.call

There isn't a need change the `alias_method_chain` since that seemed to have been addressed previously here:

https://github.com/ManageIQ/jquery-rjs/commit/5ed5e95bde762751078793b6a164f068496f58e0

Probably should be a major version update for this gem, but that can be up for discussion.

Links
-----

- Cross Repo PR (with this in place): https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/179