### PR TITLE
Support ruby 3 arguments and drop alias_method_chain in favor of Module#prepend

### DIFF
--- a/lib/jquery-rjs.rb
+++ b/lib/jquery-rjs.rb
@@ -6,11 +6,6 @@ unless defined? JQUERY_VAR
 end
 
 module JqueryRjs
-  def use_alias_method_chain?
-    @use_alias_method_chain ||= RUBY_VERSION < '2'
-  end
-  module_function :use_alias_method_chain?
-
   class Engine < Rails::Engine
     initializer 'jquery-rjs.initialize' do
       ActiveSupport.on_load(:action_controller) do

--- a/lib/jquery-rjs/rendering.rb
+++ b/lib/jquery-rjs/rendering.rb
@@ -6,8 +6,8 @@ module JqueryRjs::RenderingHelper
     if options == :update
       update_page(&block)
     else
-      args = options, locals, block
-      JqueryRjs.use_alias_method_chain? ? render_without_update(*args) : super(*args)
+      args = options, locals
+      JqueryRjs.use_alias_method_chain? ? render_without_update(*args, &block) : super(*args, &block)
     end
   end
 end

--- a/lib/jquery-rjs/rendering.rb
+++ b/lib/jquery-rjs/rendering.rb
@@ -1,23 +1,14 @@
 require 'action_view/helpers/rendering_helper'
 
 module JqueryRjs::RenderingHelper
-  method_name = "render#{'_with_update' if JqueryRjs.use_alias_method_chain?}"
-  define_method(method_name) do |options = {}, locals = {}, &block|
+  define_method("render") do |options = {}, locals = {}, &block|
     if options == :update
       update_page(&block)
     else
       args = options, locals
-      JqueryRjs.use_alias_method_chain? ? render_without_update(*args, &block) : super(*args, &block)
+      super(*args, &block)
     end
   end
 end
 
-
-if JqueryRjs.use_alias_method_chain?
-  ActionView::Helpers::RenderingHelper.module_eval do
-    include JqueryRjs::RenderingHelper
-    alias_method_chain :render, :update
-  end
-else
-  ActionView::Helpers::RenderingHelper.prepend(JqueryRjs::RenderingHelper)
-end
+ActionView::Helpers::RenderingHelper.prepend(JqueryRjs::RenderingHelper)

--- a/lib/jquery-rjs/selector_assertions.rb
+++ b/lib/jquery-rjs/selector_assertions.rb
@@ -197,7 +197,7 @@ module JqueryRjs::SelectorAssertions
 
   # +assert_select+ and +css_select+ call this to obtain the content in the HTML
   # page, or from all the RJS statements, depending on the type of response.
-  define_method("response_from_page#{'_with_rjs' if JqueryRjs.use_alias_method_chain?}") do
+  define_method("response_from_page") do
     content_type = @response.content_type
 
     if content_type && Mime[:js] =~ content_type
@@ -216,7 +216,7 @@ module JqueryRjs::SelectorAssertions
 
       root
     else
-      JqueryRjs.use_alias_method_chain? ? response_from_page_without_rjs : super()
+      super()
     end
   end
 
@@ -240,11 +240,4 @@ module_to_patch = if defined?(ActionDispatch::Assertions::SelectorAssertions)
                     Rails::Dom::Testing::Assertions::SelectorAssertions
                   end
 
-if JqueryRjs.use_alias_method_chain?
-  module_to_patch.module_eval do
-    include JqueryRjs::SelectorAssertions
-    alias_method_chain :response_from_page, :rjs
-  end
-else
-  module_to_patch.prepend(JqueryRjs::SelectorAssertions)
-end
+module_to_patch.prepend(JqueryRjs::SelectorAssertions)


### PR DESCRIPTION
Testing this with https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/706

Ok, green.

* Drops alias_method_chain logic as prepend has been available since 2.0
* args handling with passing blocks is changed with ruby 3, so pass the block directly and not included in an array of args.