### PR TITLE
Resurrect capture of blocks for RJS update in rails 7.1

### DIFF
--- a/lib/jquery-rjs/action_controlller_rendering.rb
+++ b/lib/jquery-rjs/action_controlller_rendering.rb
@@ -1,0 +1,14 @@
+if Rails.version >= "7.1.0.0"
+  require 'action_controller/metal/rendering'
+
+  module JqueryRjs::ActionControllerRendering
+    # Normalize arguments by catching blocks and setting them on :update.
+    def _normalize_args(action = nil, options = {}, &blk)
+      options = super
+      options[:update] = blk if block_given?
+      options
+    end
+  end
+
+  ActionController::Rendering.prepend(JqueryRjs::ActionControllerRendering)
+end

--- a/lib/jquery-rjs/on_load_action_controller.rb
+++ b/lib/jquery-rjs/on_load_action_controller.rb
@@ -1,2 +1,3 @@
+require 'jquery-rjs/action_controlller_rendering'
 require 'jquery-rjs/selector_assertions'
 require 'jquery-rjs/renderers'


### PR DESCRIPTION
Bring back the rails 7.0 version of _normalize_args from action_controller/metal/rendering.rb

This is a pseudo-revert of the removal in upstream: https://github.com/rails/rails/commit/4bd6251a15f13b645d96862a1ff3cfb5e0ffefdd

RJS needs to be removed but this allows it to work with 7.1 until it can be removed.

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
