### PR TITLE
Fix AS::ProxyObject deprecation in rails 7.2

### DIFF
--- a/lib/action_view/helpers/jquery_helper.rb
+++ b/lib/action_view/helpers/jquery_helper.rb
@@ -725,7 +725,7 @@ module ActionView
     end
 
     # Converts chained method calls on DOM proxy elements into JavaScript chains
-    class JavaScriptProxy < (Rails::VERSION::MAJOR >= 4) ? ::ActiveSupport::ProxyObject : ::ActiveSupport::BasicObject #:nodoc:
+    class JavaScriptProxy < (Rails.version >= "7.2") ? ::BasicObject : ::ActiveSupport::ProxyObject #:nodoc:
 
       def initialize(generator, root = nil)
         @generator = generator


### PR DESCRIPTION
This was seen in other repos' test suite.

Before:

```
% be rspec spec/models/vm_spec.rb
** override_gem("jquery-rjs", :path=>"/Users/joerafaniello/Code/jquery-rjs") at /Users/joerafaniello/Code/manageiq/bundler.d/Gemfile.dev.rb:5
** Using session_store: ActionDispatch::Session::MemoryStore
DEPRECATION WARNING: ActiveSupport::ProxyObject is deprecated and will be removed in Rails 8.0.
Use Ruby's built-in BasicObject instead.
 (called from <module:Helpers> at /Users/joerafaniello/Code/jquery-rjs/lib/action_view/helpers/jquery_helper.rb:728)
DEPRECATION WARNING: ActiveSupport::ProxyObject is deprecated and will be removed in Rails 8.0.
Use Ruby's built-in BasicObject instead.
 (called from <module:Helpers> at /Users/joerafaniello/Code/jquery-rjs/lib/action_view/helpers/jquery_helper.rb:767)
DEPRECATION WARNING: ActiveSupport::ProxyObject is deprecated and will be removed in Rails 8.0.
Use Ruby's built-in BasicObject instead.
 (called from <module:Helpers> at /Users/joerafaniello/Code/jquery-rjs/lib/action_view/helpers/jquery_helper.rb:811)
DEPRECATION WARNING: ActiveSupport::ProxyObject is deprecated and will be removed in Rails 8.0.
Use Ruby's built-in BasicObject instead.
 (called from <module:Helpers> at /Users/joerafaniello/Code/jquery-rjs/lib/action_view/helpers/jquery_helper.rb:836)
DEPRECATION WARNING: ActiveSupport::ProxyObject is deprecated and will be removed in Rails 8.0.
Use Ruby's built-in BasicObject instead.
 (called from <module:Helpers> at /Users/joerafaniello/Code/jquery-rjs/lib/action_view/helpers/jquery_helper.rb:934)
```

After:

```
% be rspec spec/models/vm_spec.rb
** override_gem("jquery-rjs", :path=>"/Users/joerafaniello/Code/jquery-rjs") at /Users/joerafaniello/Code/manageiq/bundler.d/Gemfile.dev.rb:5
** Using session_store: ActionDispatch::Session::MemoryStore
** ManageIQ master, codename: Tal

Randomized with seed 63411
...........................................................

Finished in 8.88 seconds (files took 5.95 seconds to load)
59 examples, 0 failures
```

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
